### PR TITLE
Remove json dependency, which isn't installable

### DIFF
--- a/stock-ticker.el
+++ b/stock-ticker.el
@@ -6,7 +6,7 @@
 ;; Version: 0.1
 ;; Keywords: comms
 ;; URL: https://github.com/hagleitn/stock-ticker
-;; Package-Requires: ((dash "2.4.0") (json "1.4") (s "1.9.0") (request "0.2.0"))
+;; Package-Requires: ((dash "2.4.0") (s "1.9.0") (request "0.2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
It's okay to omit this: `json` is in Emacs 23.3 and up, and there's no 1.4 version available for download anyway, so this dependency would just have made the package uninstallable in some Emacs versions.
